### PR TITLE
Adding TopMed supporting data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-pandas==1.2.3
-numpy
-pyranges==0.0.95
-htslib
-zlib
-cyvcf2==0.30.4
-ncls==0.0.57
-python>=3

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,11 @@ setup(
         "License :: MIT License",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering :: Bio-Informatics"]
+        "Topic :: Scientific/Engineering :: Bio-Informatics"],
+
+    install_requires=["pandas",
+                      "numpy",
+                      "pyranges",
+                      "cyvcf2"]
 )
 


### PR DESCRIPTION
Hello,

Thank you for building this tool. It is very useful and I expect it will be widely adopted as more people learn about it.

My team is putting together a publication for [TopMed](https://topmed.nhlbi.nih.gov/) about an SV callset over 138,134 samples and their 376,478 variants. The preprint can be found [here](https://www.biorxiv.org/content/10.1101/2023.01.25.525428v1).
We're currently working through the first round of reviews on the manuscript and the question was asked about how users could leverage these results. Our idea was to use SVAFotate for analysis of TopMed and then to add its variants and allele frequencies to SVAFotate's supporting data.

This pull request makes two changes:
- Editing `setup.py` to allow the package to be installable via `python3 -m pip install . `
- Adding TopMed variants to the supporting data.

We couldn't provide population/sex specific information in the supporting data as permissions to phenotype information across the cohorts which comprise this sample set is heterogeneous. 

Hopefully, I was able to incorporate the new calls correctly. I have run this updated supporting data file on another cohort's ~17k samples' SVs successfully, but I don't believe that's qualifies as proper functional testing and you may want to test further.

Also, we can imagine this change could drive-up users which might increase the number of issues. Therefore, I'll be monitoring the tickets periodically for ways I can continue to help. If you ever encounter something that you think needs my input, do not hesitate to ask. The last thing I want is to add any undue burden to you. I am more than happy to take responsibility for helping with the continued maintenance of SVAFotate.

Please let me know if you have any questions or anything else you need from me. 

Have a great day,
~/Adam English